### PR TITLE
Fix keyword package in setup.py for setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name='pyews',
           'Programming Language :: Python :: Implementation :: PyPy',
           'Topic :: Text Processing :: Markup :: XML',
       ],
-      py_modules=['pyews'],
+      packages=['pyews'],
       tests_require=['nose>=1.0', 'coverage'],
       install_requires=['requests==2.9.1', 'tornado==4.3'],
       )


### PR DESCRIPTION
Otherwise you can install it but you won't have the package installed and thus you won't be able to import pyews